### PR TITLE
Allow customize role name

### DIFF
--- a/backup_function.tf
+++ b/backup_function.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "ebs_backup_role" {
-  name = "lambda-${var.backup_tag}-role"
+  name = "${var.iam_role_name}"
 
   assume_role_policy = <<EOF
 {

--- a/variables.tf
+++ b/variables.tf
@@ -27,3 +27,8 @@ variable "retention_lambda_name" {
   description = "Set name for retention lambda func"
   default     = "ebs_snapshot_janitor"
 }
+
+variable "iam_role_name" {
+  description = "Set name for iam role"
+  default     = "lambda-backup-role"
+}


### PR DESCRIPTION
Allows setting custom iam role name. Used when you need to create several lambdas with different backup time.